### PR TITLE
fixed bug in getting languages when the prefix contains more than 1 slashes

### DIFF
--- a/UDAnnotations.hs
+++ b/UDAnnotations.hs
@@ -9,7 +9,7 @@ import qualified Data.Set as S
 import Data.List
 import Data.Char
 import Data.Maybe
-
+import System.FilePath.Posix (takeBaseName)
 --------
 
 data UDEnv = UDEnv {
@@ -47,7 +47,7 @@ checkAnnotations pref eng cat = do
   putStrLn $ unlines $ checkAbsLabels env (absLabels env)
   putStrLn $ unlines $ checkCncLabels env (cncLabels env)
 
-stdLanguage pref eng = mkLanguage $ if elem '/' pref then (tail (dropWhile (/='/') pref ++ eng)) else (pref ++ eng)
+stdLanguage pref eng = mkLanguage (takeBaseName pref ++ eng)
 stdGrammarFile pref = pref ++ ".pgf"
 stdAbsLabelsFile pref = pref ++ ".labels"
 stdCncLabelsFile pref eng = pref ++ eng ++ ".labels"

--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -29,6 +29,6 @@ executable gf-ud
                , UDVisualization
 
   -- other-extensions:
-  build-depends:       base, containers, pretty, gf, process
+  build-depends:       base, containers, pretty, gf, process, filepath
   -- hs-source-dirs:
   default-language:    Haskell2010


### PR DESCRIPTION
maybe you want to fix this without importing `System.FilePath.Posix` instead, but here's another problem with paths.