### PR TITLE
modified cabal file to use gf-ud as a library

### DIFF
--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -35,3 +35,22 @@ executable gf-ud
   build-depends:       base, containers, pretty, gf, process, filepath
   -- hs-source-dirs:
   default-language:    Haskell2010
+
+  library
+  exposed-modules:
+    RTree,
+    UDStandard,
+    UDConcepts,
+    UDPatterns,
+    GFConcepts,
+    UDAnnotations,
+    UD2GF,
+    BuildGFGrammar
+  other-modules:
+    Backend,
+    DBNF,
+    UDAnalysis,
+    UDOptions,
+    UDVisualization
+  build-depends:       base, containers, pretty, gf, process, filepath
+  default-language:    Haskell2010

--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -45,8 +45,7 @@ library
     GFConcepts,
     UDAnnotations,
     UD2GF,
-    BuildGFGrammar
-  other-modules:
+    BuildGFGrammar,
     Backend,
     DBNF,
     UDAnalysis,

--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -36,7 +36,7 @@ executable gf-ud
   -- hs-source-dirs:
   default-language:    Haskell2010
 
-  library
+library
   exposed-modules:
     RTree,
     UDStandard,

--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -42,14 +42,17 @@ library
     UDStandard,
     UDConcepts,
     UDPatterns,
+    UDAnalysis,
+    UDOptions,
+    UDVisualization,
+    TransformUD,
     GFConcepts,
     UDAnnotations,
     UD2GF,
     BuildGFGrammar,
     Backend,
     DBNF,
-    UDAnalysis,
-    UDOptions,
-    UDVisualization
+    AutoAnnotations
+
   build-depends:       base, containers, pretty, gf, process, filepath
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.26
+resolver: ghc-8.4.4 # lts-15.9
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: ghc-8.4.4 # lts-15.9
+resolver: lts-12.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
for the moment, all modules are exposed excepts:
- `MainUdGF` (for obvious reasons)
- `ParParse` (because it was not compiling with the current configuration)