### PR TITLE
ignore comments not referring to a specific UD sentence

### DIFF
--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -71,7 +71,8 @@ parseUDFile :: FilePath -> IO [UDSentence]
 parseUDFile f = readFile f >>= return . parseUDText
 
 parseUDText :: String -> [UDSentence]
-parseUDText = map prss . stanzas . lines
+parseUDText = map prss . stanzas . filter (not . isGeneralComment) . lines
+  where isGeneralComment line = "##" `isPrefixOf` line
 
 -- shorthand
 conlluFile2UDTrees :: FilePath -> IO [UDTree]


### PR DESCRIPTION
Example:
```
## COMPOSE [FILTER_SUBTREES (OR [...])]
```
as the first line of a UD text (added by `pattern-replace`).