### PR TITLE
Misc changes needed for improving concept alignment

### DIFF
--- a/RTree.hs
+++ b/RTree.hs
@@ -5,7 +5,7 @@ data RTree a = RTree {
   root   :: a,
   subtrees :: [RTree a] 
   }
-  deriving (Eq,Show)
+  deriving (Eq,Show,Read)
 
 mapRTree :: (a -> b) -> RTree a -> RTree b
 mapRTree f (RTree c ts) = RTree (f c) (map (mapRTree f) ts)

--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -11,6 +11,7 @@ import UDStandard
 import qualified Data.Set as S
 import qualified Data.Map as M
 import Data.List
+import Data.List.Split
 import Data.Char
 
 -- text paragraph representing the tree of a sentence

--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -240,7 +240,7 @@ udTree2sentence t = UDSentence {
 
 -- return the id of a sentence, taken from the comment that precedes it
 sentId :: UDSentence -> String 
-sentId s = if hasSentId s then head $ words $ head idEtc else "missing sent_id"
+sentId s = if hasSentId s then head $ words $ head idEtc else error "missing sent_id"
   where
     hasSentId s = (not . null) idEtc
     (_:idEtc) = splitOn "sent_id = " (unwords (concatMap words (udCommentLines s)))

--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -45,6 +45,9 @@ data UDWord = UDWord {
 type POS = String
 type Label = String
 
+instance Read UDWord where
+  readsPrec _ s = [(prs s :: UDWord, "")]
+
 -- useless because one could just use isSubRTree, but...
 isSubUDTree :: UDTree -> UDTree -> Bool
 isSubUDTree t u = t == u || any (isSubUDTree t) (subtrees u)

--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -168,13 +168,13 @@ instance UDObject d => UDObject [d] where
 -- # sent_id = gfud1000001
 -- # text = in the computer
 prUDSentence :: Int -> UDSentence -> String
-prUDSentence i = prt . addMeta i
+prUDSentence i s = (prt . addMeta i) s
  where
    addMeta i u = u {
      udCommentLines = [
        "# sent_id = gfud" ++ show (1000000 + i),
        "# text = " ++ unwords (map udFORM (udWordLines u))
-       ]
+       ] ++ udCommentLines s
      }
 
 prReducedUDSentence :: String -> UDSentence -> String

--- a/UDConcepts.hs
+++ b/UDConcepts.hs
@@ -237,6 +237,13 @@ udTree2sentence t = UDSentence {
   udWordLines = sortOn udID (allNodesRTree t)
   }
 
+-- return the id of a sentence, taken from the comment that precedes it
+sentId :: UDSentence -> String 
+sentId s = if hasSentId s then head $ words $ head idEtc else "missing sent_id"
+  where
+    hasSentId s = (not . null) idEtc
+    (_:idEtc) = splitOn "sent_id = " (unwords (concatMap words (udCommentLines s)))
+
 prUDTree :: UDTree -> String
 prUDTree = prLinesRTree prt
 

--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -32,7 +32,7 @@ executable gf-ud
                , UDPatterns
 
   -- other-extensions:
-  build-depends:       base, containers, pretty, gf, process, filepath
+  build-depends:       base, containers, pretty, gf, process, filepath, split
   -- hs-source-dirs:
   default-language:    Haskell2010
 
@@ -53,5 +53,5 @@ library
     DBNF,
     AutoAnnotations
 
-  build-depends:       base, containers, pretty, gf, process, filepath
+  build-depends:       base, containers, pretty, gf, process, filepath, split
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,6 +47,7 @@ extra-deps:
 - random-1.1@sha256:7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df,1777
 - syb-0.7.1@sha256:8d37b1e4d04a9aa8512dc6c2a06e02afc015a2fd3e735bdfeeacb5e2e853323c,2462
 - utf8-string-1.0.1.1@sha256:68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b,1151
+- split-0.2.3.4@sha256:048c75891d63a03828f97667214aaaf0e67b7dcbfec297753e39939ffda6f51a,2647
 
 # The following packages have been ignored due to incompatibility with the
 # resolver compiler, dependency conflicts with other packages


### PR DESCRIPTION
I needed to do various things, so here is a summary:
- added `read` for `RTree`s and `UDWords`
- made `prUDSentence` also include preexisting comment lines
- added a function that returns the `sent_id` of a `UDSentence` (from its comment lines)