### PR TITLE
Expose GF2UD in the library

### DIFF
--- a/gf-ud.cabal
+++ b/gf-ud.cabal
@@ -49,6 +49,7 @@ library
     GFConcepts,
     UDAnnotations,
     UD2GF,
+    GF2UD,
     Backend,
     DBNF,
     AutoAnnotations


### PR DESCRIPTION
Is there a reason why GF2UD isn't among the exposed modules, or was it just forgotten?

(I can merge this myself, but thought just to confirm if it's intended or not.)