### PR TITLE
Expand the capabilities of macros

### DIFF
--- a/UDAnnotations.hs
+++ b/UDAnnotations.hs
@@ -292,6 +292,8 @@ expandMacro env tr@(RTree f ts) = case M.lookup f (macroFunctions (cncLabels env
  where
    subst xts t@(RTree h us) = case us of
      [] -> maybe t id (lookup h xts)
+     -- Expand head: #auxfun Ex a b : A -> B -> C = a b ; cn head
+     _ | Just (RTree h' hus) <- lookup h xts -> RTree h' (hus ++ map (subst xts) us)
      _  -> RTree h (map (subst xts) us)
 
 ----------------------------------------------------------------------------

--- a/UDAnnotations.hs
+++ b/UDAnnotations.hs
@@ -287,10 +287,13 @@ catsForPOS env = M.fromListWith (++) $
 -- CId (AbsType,(([CId],AbsTree),[Label]))
 expandMacro :: UDEnv -> AbsTree -> AbsTree
 expandMacro env tr@(RTree f ts) = case M.lookup f (macroFunctions (cncLabels env)) of
-  Just (MacroFunction _ xx df _) -> subst (zip xx (map (expandMacro env) ts)) df
-  _ -> RTree f (map (expandMacro env) ts)
+  Just (MacroFunction _ xx df _) | length ts' == length xx -> 
+    subst (zip xx ts') df
+  _ -> RTree f ts'
  where
-   subst xts t@(RTree h us) = case us of
+   ts' = map (expandMacro env) ts
+   subst xts t@(RTree h us) = 
+    case us of
      [] -> maybe t id (lookup h xts)
      -- Expand head: #auxfun Ex a b : A -> B -> C = a b ; cn head
      _ | Just (RTree h' hus) <- lookup h xts -> expandMacro env $ RTree h' (hus ++ map (subst xts) us)

--- a/UDAnnotations.hs
+++ b/UDAnnotations.hs
@@ -293,7 +293,7 @@ expandMacro env tr@(RTree f ts) = case M.lookup f (macroFunctions (cncLabels env
    subst xts t@(RTree h us) = case us of
      [] -> maybe t id (lookup h xts)
      -- Expand head: #auxfun Ex a b : A -> B -> C = a b ; cn head
-     _ | Just (RTree h' hus) <- lookup h xts -> RTree h' (hus ++ map (subst xts) us)
+     _ | Just (RTree h' hus) <- lookup h xts -> expandMacro env $ RTree h' (hus ++ map (subst xts) us)
      _  -> RTree h (map (subst xts) us)
 
 ----------------------------------------------------------------------------

--- a/UDAnnotations.hs
+++ b/UDAnnotations.hs
@@ -288,6 +288,7 @@ catsForPOS env = M.fromListWith (++) $
 expandMacro :: UDEnv -> AbsTree -> AbsTree
 expandMacro env tr@(RTree f ts) = case M.lookup f (macroFunctions (cncLabels env)) of
   Just (MacroFunction _ xx df _) | length ts' == length xx -> 
+    expandMacro env $
     subst (zip xx ts') df
   _ -> RTree f ts'
  where
@@ -296,7 +297,7 @@ expandMacro env tr@(RTree f ts) = case M.lookup f (macroFunctions (cncLabels env
     case us of
      [] -> maybe t id (lookup h xts)
      -- Expand head: #auxfun Ex a b : A -> B -> C = a b ; cn head
-     _ | Just (RTree h' hus) <- lookup h xts -> expandMacro env $ RTree h' (hus ++ map (subst xts) us)
+     _ | Just (RTree h' hus) <- lookup h xts -> RTree h' (hus ++ map (subst xts) us)
      _  -> RTree h (map (subst xts) us)
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
With this, you can write tiny programs in macros, for example to change the shape of a tree between GF and ud.

For example, this code allows ud2gf to handle phrases like "small, fluffy and cute":

```haskell
#auxcat Comma PUNCT
#auxfun CommaAP_ ap comma : AP -> Comma -> APComma =  ap ; head punct


-- -- #auxfun AndCutePatternMatch_ and cute : Conj -> AP -> AP2AP = MkAP2AP and cute ; cc head
#auxfun AndCuteCont_ and cute : Conj -> AP -> Pair_Conj_AP = MkPair_ and cute ; cc head

-- #auxfun AP2_ small (MkAP2AP and cute) : AP -> AP2AP -> AP = ConjAP and (BaseAP small cute)) ; head conj
#auxfun AP2_ small andCute : AP -> Pair_Conj_AP -> AP = UsePair_ (AP2_helper_ small) andCute ; head conj
#auxfun AP2_helper_ small and cute :  AP -> Conj -> AP -> AP = ConjAP and (BaseAP small cute) ; head dummy nonexsistent

-- #auxfun APBaseComma_ small fluffy (MkAP2AP and cute)  : AP -> APComma -> AP2AP -> ConjListAP = ConjConsAP and small (BaseAP fluffy cute) ; head conj conj
#auxfun APBaseComma_ small fluffy andCute : AP -> APComma -> Pair_Conj_AP -> ConjListAP = UsePair_ (APBaseComma_helper_ small fluffy) andCute ; head conj conj
#auxfun APBaseComma_helper_ small fluffy and cute : AP -> APComma -> Conj -> AP -> ConjListAP = MkTriple_ and small (BaseAP fluffy cute) ; head dummy dummy

-- #auxfun ConjListToAP2_ (ConjConsAP and small furryFluffyCute) : ConjListAP -> AP = ConjAP and (ConsAP small furryFluffyCute) ; head
#auxfun ConjListToAP2_ and_small_furryFluffyCute : ConjListAP -> AP = UseTriple_ ConjListToAP2_helper_ and_small_furryFluffyCute ; head
#auxfun ConjListToAP2_helper_ and small furryFluffyCute : Conj -> AP -> ListAP -> AP = ConjAP and (ConsAP small furryFluffyCute) ; notreal head dummy

-- #auxfun APAddComma_ furry (ConjConsAP and small fluffyAndCute)  : APComma -> ConjListAP -> ConjListAP = ConjConsAP and small (ConsAP furry fluffyAndCute) ; conj head
#auxfun APAddComma_ furry and_small_fluffyCute  : APComma -> ConjListAP -> ConjListAP = UseTriple_ (APAddComma_helper_ furry) and_small_fluffyCute ; conj head
#auxfun APAddComma_helper_ furry and small fluffyCute : APComma -> Conj -> AP -> ListAP -> ConjListAP = MkTriple_ and small (ConsAP furry fluffyCute) ; dummy head

-- Only used inside other macros
-- Pair_a_b = (a -> b -> r) -> r
#auxfun MkPair_ a b handler : a -> b -> ab2r -> r = handler a b ; head dummy nonexsistent
#auxfun UsePair_ handler pair : ab2r -> Pair_a_b -> r = pair handler ; head dummy
-- Triple_a_b_c = (a -> b -> r) -> r
#auxfun MkTriple_ a b c handler : a -> b -> c -> abc2r -> r = handler a b c ; head dummy nonexsistent nope
#auxfun UseTriple_ handler triple : abc2r -> Triple_a_b_c -> r = triple handler ; head dummy

```

This is pretty hacky though, since some of the macros aren't really real macros, but are only used inside other macros during macro expansion, so it would be nice to have a cleaner solution where you aren't forced to write dummy labels and types.