### PR TITLE
Use default options if all used options are non-printing

### DIFF
--- a/MainUDGF.hs
+++ b/MainUDGF.hs
@@ -17,7 +17,7 @@ import PGF
 import System.Environment (getArgs)
 import Control.Concurrent
 import Control.Monad
-import Data.List(sortOn)
+import Data.List(sortOn, (\\))
 import Data.Char(isDigit)
 
 -- to get parallel processing:
@@ -225,10 +225,12 @@ helpMsg = unlines $ [
     ] ++ ["  " ++ opt ++ "\t" ++ msg | (opt,msg) <- fullOpts]
 
 convertGFUD :: String -> Opts -> UDEnv -> IO ()
-convertGFUD dir opts env = case dir of
-  "ud2gf" -> getContents >>= ud2gfOpts (if null opts then defaultOptsUD2GF else opts) env
-  "ud2gfparallel" -> getContents >>= ud2gfOptsPar (if null opts then defaultOptsUD2GF else opts) env
-  _ -> do
+convertGFUD dir opts env = 
+  let optsU2G = if null (opts \\ nonPrintingOpts) then opts ++ defaultOptsUD2GF else opts
+  in case dir of
+    "ud2gf" -> getContents >>= ud2gfOpts optsU2G env
+    "ud2gfparallel" -> getContents >>= ud2gfOptsPar optsU2G env
+    _ -> do
       s <- getContents
       let conv = case dir of
             "gf2ud" -> G.testTreeString

--- a/UDOptions.hs
+++ b/UDOptions.hs
@@ -5,6 +5,7 @@ module UDOptions where
 -- ud2gf
 minimalOptsUD2GF = selectOpts ["at"]
 defaultOptsUD2GF = selectOpts ["msg","ud","err","bt0","at","tc","lin","sum","stat"]
+nonPrintingOpts = selectOpts ["no-backups"]
 
 -- gf2ud
 minimalOptsGF2UD = selectOpts ["ud"]


### PR DESCRIPTION
Fix of #25

If you would run
```
gf-ud ud2gf Grammar Lang Startcat no-backups
```
it would print nothing, since no-backups only changes the behaviour of other printouts. With this change it adds the default options as the `no-backups` option.