### PR TITLE
Debug-assistant for ud2gf labels

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,380 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  # - module_header:
+  #     # How many spaces use for indentation in the module header.
+  #     indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+  #     sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+  #     separate_lists: true
+  #
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+  #     break_where: exports
+  #
+  #     # Where to put open bracket
+  #     # Possible values:
+  #     # - same_line: put open bracket on the same line as the module name, before the
+  #     #              comment of the module
+  #     # - next_line: put open bracket on the next line, after module comment
+  #     open_bracket: next_line
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Whether or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: none
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Post qualify option moves any qualifies found in import declarations
+      # to the end of the declaration. This also adjust padding for any
+      # unqualified import declarations.
+      #
+      # - true: Qualified as <module name> is moved to the end of the
+      #   declaration.
+      #
+      #   > import Data.Bar
+      #   > import Data.Foo qualified as F
+      #
+      # - false: Qualified remains in the default location and unqualified
+      #   imports are padded to align with qualified imports.
+      #
+      #   > import           Data.Bar
+      #   > import qualified Data.Foo as F
+      #
+      # Default: false
+      post_qualify: false
+
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-# LANGUAGE #-}'.
+      #
+      # - vertical_compact: Similar to vertical, but use only one language pragma.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,18 @@
+## Debugging feature:
+
+Answer the question: Why doesn't this function apply?
+
+Possible input formats:
+* FunctionName 6 3 2
+* FunctionName (Sub tree1) (More (Trees of stuff))
+* FunctionName words for subtrees
+
+What to show:
+* When features doesn't match
+* When labels and cats doesn't match
+
+
+Maybe start from the final devtree and recreate work so we can prioritize simpler diffs.
+We could even tell why a tree that was created wasn't included and
+if a subtree of what we asked for is missing, we can answer that.
+

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -378,6 +378,7 @@ debugAuxFun' env dt funId argIds = either ("Error: " ++) id $ do
        ++ unwords ([ lab ++ showAttrs b | (_,(lab,b)) <- argCatLabs])
   
   -- Find the function definition
+  -- TODO: Merge this with the arg handling below
   (f,(outCat, argCatLabs)) <- case [(f,labtyp) | (f,labtyp) <- allFunsEnv env, f == funId] of
     [] -> Left $ "Unknown function: " ++ show funId
     [(f,labtyp)] -> pure (f,labtyp)

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -19,7 +19,7 @@ import Text.PrettyPrint (cat, render)
 import Debug.Trace (trace, traceM)
 import Data.Function (on)
 import Data.Ord (comparing)
-import Control.Monad (unless, forM)
+import Control.Monad (unless, forM, when)
 
 ---------
 -- to debug
@@ -343,6 +343,9 @@ getInt _ = Nothing
 debugAuxFun' :: UDEnv -> DevTree -> CId -> [Int] -> String
 debugAuxFun' env dt funId argNrs = either ("Error: " ++) id $ do
   traceM $ "\nStarting debug for " ++ showCId funId ++ ":"
+  unless (M.notMember funId (disabledFunctions (cncLabels env))) $
+    Left $ "The function " ++ showCId funId ++ " is disabled"
+
   (f,(outCat, argCatLabs)) <- case [(f,labtyp) | (f,labtyp) <- allFunsEnv env, f == funId] of
     [] -> Left $ "Unknown function: " ++ show funId
     [(f,labtyp)] -> pure (f,labtyp)

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -359,7 +359,7 @@ debugAuxFun' env dt funId argNrs = either ("Error: " ++) id $ do
   traceM showFun
   let catLabNrs = zip argNrs argCatLabs
   let catlabHeads = filter (\(nr,(cat,(lab,feats))) -> lab == head_Label) catLabNrs
-  (headNr, catlabHead) <- case catlabHeads of [ch] -> pure ch; _ -> Left ("Missing head label for function: " ++ show f ++ "\nlabels: " ++ show argCatLabs)
+  (headNr, catlabHead) <- case catlabHeads of [ch] -> pure ch; _ -> Left ("Missing head label for function: " ++ show f ++ "\nlabels: " ++ unwords (map (fst . snd) argCatLabs))
 
   -- Step 1. find where the head is in the tree
   headTree <- case findNode env (UDIdInt headNr) dt of

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -378,14 +378,17 @@ debugAuxFun' env dt funId argNrs = either ("Error: " ++) id $ do
     ++ "\". Head features: " ++ showAttrs (devFeats headNode)
   let headAT = devAbsTrees headNode
   let goodTrees = [ x | x <- headAT , atiCat x == fst catlabHead]
+  when (null goodTrees) $ Left $ "No trees with expected category for " ++ showCId f ++ " with head \"" ++ devWord headNode ++ "\"\n" 
+    ++ "Expected category: " ++ show (fst catlabHead) ++ "\n"
+    ++ "Available categories: " ++ show (map atiCat headAT)
   traceM $ "Found head trees with correct category: " ++ intercalate "\n" (map (prRTree showCId . atiAbsTree) goodTrees)
 
   -- 4. Check that the arguments are compatible with the function
   let badLabels = [(node, lab) | (node, (cat,(lab,feats))) <- childNodes, devLabel node /= lab]
-  unless (null badLabels) $ Left $ ("Incompatible argument labels:\n" ++) $ 
+  unless (null badLabels) $ Left $ ("Incompatible argument labels:\n" ++) $
     intercalate "\n" [ " - For " ++ show (devWord node) ++ ": Got " ++ devLabel node ++ " expected " ++ lab | (node,lab) <- badLabels]
   let badAttrs = [(node, missingFeats) | (node, (cat,(lab,feats))) <- childNodes, let missingFeats = filter (`notElem`devFeats node) feats, not (null missingFeats)]
-  unless (null badAttrs) $ Left $ ("Missing argument features:\n" ++) $ 
+  unless (null badAttrs) $ Left $ ("Missing argument features:\n" ++) $
     intercalate "\n" [ " - For " ++ show (devWord node) ++ ": Missing features " ++ showAttrs feats ++ " from " ++ showAttrs (devFeats node) | (node,feats) <- badAttrs]
   -- TODO: Check the category of the arguments
   -- TODO: Check that the constructed tree exists in the UD tree and if it would be selected

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -501,7 +501,7 @@ combineTrees env =
   tryFindArgsFast  f (_, catlabs) (headArgs:argss) =
     [ (abstree,usage)
     | let catlabHeads = filter (\(cat,(lab,feats)) -> lab == head_Label) catlabs
-    , let catlabHead = case catlabHeads of [ch] -> ch; _ -> error ("Missing head label for function: " ++ show f ++ "\nlabels: " ++ show catlabs)
+    , let catlabHead = case catlabHeads of [ch] -> ch; _ -> error ("Missing head label for function: " ++ show f ++ "\nlabels: " ++ unwords (map (fst . snd) catlabs))
       -- Select a headArg matching labcatHead
       -- Filter out argss according to use from the headArg
       -- Select other args until done

--- a/UD2GF.hs
+++ b/UD2GF.hs
@@ -1,24 +1,24 @@
 module UD2GF where
 
-import RTree
-import UDConcepts
-import UDAnnotations
+import Backend
 import GFConcepts
+import RTree
+import UDAnnotations
+import UDConcepts
 import UDOptions
 import UDVisualization
-import Backend
 
 import PGF hiding (CncLabels)
 
-import qualified Data.Map as M
-import Data.List
 import Data.Char
+import Data.List
+import qualified Data.Map as M
 import Data.Maybe
-import Text.PrettyPrint (render, cat)
+import Text.PrettyPrint (cat, render)
 
-import Debug.Trace (trace)
 import Data.Function (on)
 import Data.Ord (comparing)
+import Debug.Trace (trace)
 
 ---------
 -- to debug
@@ -66,7 +66,7 @@ showUD2GF opts env sentence = do
   ifOpt opts "ud" $ prt sentence
 
   case errors sentence of
-    [] -> return ()
+    []   -> return ()
     errs -> ifOpt opts "err" $ unlines errs
 
   let udtree = udSentence2tree sentence
@@ -132,11 +132,11 @@ showUD2GF opts env sentence = do
 
 
 data UD2GFStat = UD2GFStat {
-  totalWords :: Int,
-  interpretedWords :: Int,
-  unknownWords :: Int,
-  totalSentences :: Int,
-  completeSentences :: Int,
+  totalWords           :: Int,
+  interpretedWords     :: Int,
+  unknownWords         :: Int,
+  totalSentences       :: Int,
+  completeSentences    :: Int,
   typecorrectSentences :: Int
   }
  deriving Show
@@ -172,7 +172,7 @@ data CheckResult = CheckResult {
 
 prCheckResult cr = unlines $
   case resultUnknowns cr of
-    [] -> []
+    []  -> []
     uks -> [unwords $ "unknown words:" : map showCId uks]
   ++
   [resultMessage cr]
@@ -187,7 +187,7 @@ checkAbsTreeResult env t = CheckResult {
  where
   pgf = pgfGrammar env
   (mt,msg) = case inferExpr pgf (abstree2expr t) of
-    Left tce -> (Nothing, render (ppTcError tce))
+    Left tce        -> (Nothing, render (ppTcError tce))
     Right (exp,typ) -> (Just exp, "type checking OK")
 
 
@@ -209,12 +209,12 @@ data DevNode = DevNode {
   deriving Show
 
 mapDevAbsTree :: (AbsTreeInfo -> AbsTreeInfo) -> DevNode -> DevNode
-mapDevAbsTree f dn = dn { devAbsTrees = map f (devAbsTrees dn) } 
+mapDevAbsTree f dn = dn { devAbsTrees = map f (devAbsTrees dn) }
 
 data AbsTreeInfo = AbsTreeInfo
   { atiAbsTree :: AbsTree
-  , atiCat :: Cat
-  , atiUDIds :: [UDId]
+  , atiCat     :: Cat
+  , atiUDIds   :: [UDId]
   }
   deriving (Show, Eq)
 
@@ -287,7 +287,7 @@ addBackups0 tr@(RTree dn trs) = case map collectBackup (tr:trs) of  -- backups f
 theAbsTreeInfo :: DevTree -> AbsTreeInfo
 theAbsTreeInfo dt = case devAbsTrees (root dt) of
   [t] -> t
-  _ -> error $ "no unique abstree in " ++ prDevNode 2 (root dt)
+  _   -> error $ "no unique abstree in " ++ prDevNode 2 (root dt)
 
 -- split trees showing just one GF tree in each DevTree
 splitDevTree :: DevTree -> [DevTree]
@@ -298,7 +298,7 @@ splitDevTree tr@(RTree dn trs) =
    case elem (devIndex d) usage of
     True -> case sortOn ((1000-) . sizeRTree . atiAbsTree) [dt | dt@AbsTreeInfo { atiAbsTree = t} <- devAbsTrees d, isSubRTree t ast] of
       t:_ -> RTree (d{devAbsTrees = [t]}) (map (chase t) ts)
-      _ -> error $ "wrong indexing in\n" ++ prLinesRTree (prDevNode 1) tr
+      _   -> error $ "wrong indexing in\n" ++ prLinesRTree (prDevNode 1) tr
     False -> head $ splitDevTree $ RTree (d{devNeedBackup = True}) ts ---- head
 
 prtStatus udids =  "[" ++ concat (intersperse "," (map prt udids)) ++ "]"
@@ -485,7 +485,7 @@ analyseWords env = mapRTree lemma2fun
                       all (\f -> M.notMember f (disabledFunctions (cncLabels env))) (allNodesRTree at)]
     Right c -> case elem (w,c) auxWords of
       True -> [(newWordTree w c, c)]
-      _ -> []
+      _    -> []
 
   auxWords = [(lemma,cat) | ((fun_,lemma),(cat,labels_)) <- M.assocs (lemmaLabels (cncLabels env))]
 
@@ -542,5 +542,5 @@ udtree2devtree = markClosest . initialize
 -- >>> select [1,2,3]
 -- [(1,[2,3]),(2,[1,3]),(3,[1,2])]
 select :: [a] -> [(a,[a])]
-select [] = []
+select []       = []
 select (a : as) = (a,as) : [ (b,a:bs) | (b,bs) <-select as ]

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -1,10 +1,10 @@
 module Main where
 
+import PGF
 import Test.Hspec
 import UD2GF
-import PGF
 import UDAnnotations
-import UDConcepts (UDData(UDData))
+import UDConcepts (UDData (UDData))
 
 
 myUDEnv :: IO UDEnv
@@ -40,7 +40,7 @@ bestTrees env conll = map exprStr exprs
       exprs = getExprs [] env conll
       exprStr expr = case expr of
         (x : _xs) -> showExpr [] x
-        _ -> "bestTree: ud2gf failed"
+        _         -> "bestTree: ud2gf failed"
 
 
 bestTree :: UDEnv -> String -> String
@@ -49,10 +49,10 @@ bestTree env conll = exprStr
       exprs = getExprs [] env conll
       exprStr = case exprs of
         (x : _xs) : _xss -> showExpr [] x
-        _ -> "bestTree: ud2gf failed"
+        _                -> "bestTree: ud2gf failed"
 
 theCatSleepsAlready :: String
-theCatSleepsAlready = unlines 
+theCatSleepsAlready = unlines
   [ "1\tthe\tthe\tDET\tQuant\tFORM=0\t2\tdet\t_\tFUN=DefArt"
   , "2\tcat\tcat\tNOUN\tNN\tNumber=Sing\t3\tnsubj\t_\tFUN=cat_N"
   , "3\tsleeps\tsleep\tVERB\tVBZ\tMood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin\t0\troot\t_\tFUN=sleepVBZ"


### PR DESCRIPTION
This is a tool for helping you identify why an auxfun is not used in ud2gf.

Call it like this:
```
stack run gf-ud ud2gf Test Eng UDS dbg='DetCN_anySg 1 2'
```

The numbers are the UD word numbers from the conlu file that you want to be arguments of the function.

TODO: Write more explanations of it and documentation