### PR TITLE
Use a newer stack snapshot which uses ghc-8.10.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # This default stack file is a copy of stack-ghc8.6.5.yaml
 # But committing a symlink is probably a bad idea, so it's a real copy
 
-resolver: lts-16.20
+resolver: lts-18.28
 
 
 extra-deps:


### PR DESCRIPTION
This newer version of ghc has support for M1 macbooks